### PR TITLE
Analyse #20 : désalignement vertical bandes colorées

### DIFF
--- a/app/component/pattern_player.rb
+++ b/app/component/pattern_player.rb
@@ -165,6 +165,27 @@ class PatternPlayer
     args.outputs.solids << rect
   end
 
+  # ANALYSE #20 — Positionnement vertical des bandes colorées (verte/rouge)
+  #
+  # PROBLÈME IDENTIFIÉ :
+  # La position Y est calculée de manière RELATIVE (+=) par rapport à args.layout.rect(row: 0).
+  # Or dans render_line, la position Y est définie de manière ABSOLUE (=).
+  # Si layout.rect(row: 0).y != 624, les bandes ne s'alignent pas avec le texte.
+  #
+  # Formule actuelle : rect.y += 640 - row * 20 - 354
+  #   → Y final = layout_y(row:0) + (286 - row * 20)
+  #
+  # Formule du texte (render_line) : rect.y = 640 - row * 20 + 270
+  #   → Y final = 910 - row * 20
+  #
+  # Pour un alignement parfait il faudrait : layout_y(row:0) + 286 = 910
+  #   → layout_y(row:0) devrait valoir exactement 624
+  #
+  # CORRECTIF PROPOSÉ :
+  # Utiliser la même approche absolue que render_line pour garantir l'alignement :
+  #   rect.y = 640 - row * 20 + 270 - 10
+  # Le -10 centre verticalement la bande (h=20) sur le texte (vertical_alignment_enum: 1 = centré)
+  #
   def render_current_line row,color
     rect = args.layout
       .rect(row: 0, col: 1, w: 16, h: 1).merge(**color)
@@ -177,6 +198,12 @@ class PatternPlayer
 
   end
 
+  # ANALYSE #20 — Positionnement vertical du texte des lignes
+  #
+  # Le texte utilise une position Y ABSOLUE : rect.y = 640 - row * 20 + 270
+  # C'est la référence fiable. Les bandes (render_current_line) devraient
+  # s'aligner sur cette même formule.
+  #
   def render_line pattern, num, row
     line = pattern.row_info num
     rect = args.layout.rect(row: row, col: 1)


### PR DESCRIPTION
## Summary

- Analyse en profondeur du bug de désalignement vertical entre les bandes colorées (verte aux lignes 0/16/32/48 et rouge curseur) et les lignes de texte du pattern editor
- Cause racine identifiée : `render_current_line` calcule Y de manière **relative** (`+=`) par rapport au layout, tandis que `render_line` utilise une position **absolue** (`=`). Si `layout.rect(row:0).y ≠ 624`, les deux ne s'alignent pas.
- Correctif proposé documenté dans les commentaires du code

## Détail de l'analyse

### Formules actuelles

| Élément | Méthode | Formule Y | Type |
|---------|---------|-----------|------|
| Texte des lignes | `render_line` | `rect.y = 640 - row * 20 + 270` | **Absolue** ✅ |
| Bandes colorées | `render_current_line` | `rect.y += 640 - row * 20 - 354` | **Relative** ❌ |

### Correctif proposé
Remplacer le calcul relatif de `render_current_line` par un calcul absolu aligné sur `render_line` :
```ruby
rect.y = 640 - row * 20 + 270 - 10  # -10 pour centrer la bande (h=20) sur le texte
```

## Fichiers concernés
- `app/component/pattern_player.rb` (lignes 168-200)

## Test plan
- [ ] Valider l'analyse avec le propriétaire du projet
- [ ] Appliquer le correctif proposé
- [ ] Vérifier visuellement l'alignement via screenshot

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)