### PR TITLE
Fix sample data corruption: offset and length bugs (#33)

### DIFF
--- a/app/component/pattern_player/pattern_audio.rb
+++ b/app/component/pattern_player/pattern_audio.rb
@@ -19,12 +19,15 @@ module PatternAudio
   def play_channel_sound num
     cell = @pattern.rows[@current_line][num]
     return if cell.note_period == 0
+    return if cell.sample_number == 0
     return unless @with_sound
     play_mod_sample num, cell
   end
 
+  # ProTracker samples are 1-indexed (0 = no instrument).
+  # Ruby array is 0-indexed, so subtract 1.
   def play_mod_sample num, cell
-    s = @mod.samples[cell.sample_number]
+    s = @mod.samples[cell.sample_number - 1]
     rate = amiga_rate cell.note_period
     sound = one_shot_lambda s
     args.audio["channel_#{num}".to_sym] = { input: [1, rate, sound] }

--- a/doc/draft_posts/mod_file_layout_offset_bugs.md
+++ b/doc/draft_posts/mod_file_layout_offset_bugs.md
@@ -1,0 +1,97 @@
+# MOD File Layout: Two Offset Bugs That Corrupted Every Sample
+
+## The MOD File Memory Map
+
+A ProTracker .mod file is laid out sequentially in memory:
+
+```
+Offset    Size     Content
+0         20       Song name
+20        930      31 sample headers (30 bytes each)
+950       1        Song length
+951       1        Tracker byte
+952       128      Song position table
+1080      4        Format signature ("M.K.")
+1084      N*1024   Pattern data (N patterns, 1024 bytes each)
+1084+N*1024  ...   Sample audio data (concatenated)
+```
+
+The sample audio data starts right after the last pattern.
+To find it, you need to know how many patterns there are.
+
+## Bug #1: Amiga Words vs Bytes
+
+The sample header stores lengths in **Amiga words** (2-byte units):
+
+```
+Offset  Size  Description
+42      2     Sample length (in words, multiply by 2 for bytes)
+46      2     Repeat point (in words)
+48      2     Repeat length (in words)
+```
+
+Our parser read the raw value without multiplying:
+
+```ruby
+# Before (wrong): length in words, not bytes
+@length = decode_amiga_word(@mod_data, offset)
+
+# After (correct): convert words to bytes
+@length = decode_amiga_word(@mod_data, offset) * 2
+```
+
+**Effect:** Each sample read half its actual data. The waveform showed
+the real sample followed by the beginning of the next sample.
+
+## Bug #2: Pattern Count Off-By-One
+
+To find where sample data starts, we calculate:
+
+```ruby
+def samples_start_at
+  1084 + (pattern_count * 1024)
+end
+```
+
+`pattern_count` was computed from the song position table:
+
+```ruby
+# Before (wrong): max index, not count
+def pattern_count
+  @song_positions.max  # returns 17 for patterns 0..17
+end
+
+# After (correct): count = max index + 1
+def pattern_count
+  @song_positions.max + 1  # returns 18
+end
+```
+
+**Effect:** The sample data offset was 1024 bytes too early,
+pointing into the last pattern instead of the actual sample data.
+Every sample started with 1024 bytes of pattern data garbage.
+
+## Combined Effect
+
+With both bugs active:
+- Sample data started 1024 bytes too early (pattern data leak)
+- Each sample read only half its bytes
+- The cumulative offset for subsequent samples was also halved
+- Result: every sample was a mix of wrong data from wrong locations
+
+## Visual Evidence
+
+The waveform visualization made it obvious: you could see two distinct
+wave patterns in each sample — the real audio mixed with data from
+adjacent samples or pattern data.
+
+## Lesson
+
+Binary format parsers need two things:
+1. **Unit awareness** — always check if values are in bytes, words,
+   or some other unit. The Amiga loved 16-bit words.
+2. **Fence post counting** — "the highest index" and "the count"
+   differ by one. This is the oldest bug in programming.
+
+Both bugs had the same root cause: reading the ProTracker spec too
+quickly and missing the conversion details.

--- a/doc/draft_posts/protracker_sample_indexing.md
+++ b/doc/draft_posts/protracker_sample_indexing.md
@@ -1,0 +1,78 @@
+# ProTracker Sample Indexing: Why Sample 0 Doesn't Exist
+
+## The Off-By-One That Haunts Every MOD Parser
+
+If you're writing a MOD file parser, you'll hit this bug. We did.
+
+## The Convention
+
+In ProTracker (and all Amiga MOD formats), samples are numbered **1 to 31**.
+Sample **0** means "no instrument" — the channel keeps its current state.
+
+```
+Sample 0: No instrument (silence or sustain previous)
+Sample 1: First real instrument (e.g. Kick)
+Sample 2: Second instrument (e.g. HH)
+...
+Sample 31: Last instrument
+```
+
+## Why Zero Means Nothing
+
+This is a design choice from the original Soundtracker (Karsten Obarski, 1987).
+The sample number is encoded in the pattern data alongside the note period.
+When a tracker encounters sample 0 with a valid note period, it means
+"apply an effect to the current channel without triggering a new sample."
+
+Common uses of sample 0:
+- Volume slides without retriggering
+- Portamento (pitch bend) on the current note
+- Effect-only cells
+
+It's the same principle as null/nil in programming — a marker of absence.
+
+## The Bug
+
+In Ruby, arrays are 0-indexed. The MOD file has 31 sample headers
+starting at byte 20. When you parse them:
+
+```ruby
+32.times do |num|
+  @samples.push Sample.new(num, mod_data)
+  # num=0 reads header at offset 0*30=0 → this is sample "1" (Kick)
+  # num=1 reads header at offset 1*30=30 → this is sample "2" (HH)
+end
+```
+
+So `@samples[0]` is the Kick (ProTracker sample 1).
+
+When the pattern data says "play sample 1", if you do:
+```ruby
+@mod.samples[cell.sample_number]  # sample_number=1 → HH (wrong!)
+```
+
+You get the HH instead of the Kick. Every instrument is shifted by one.
+
+## The Fix
+
+```ruby
+# Filter out "no instrument" cells
+return if cell.sample_number == 0
+
+# ProTracker 1-indexed → Ruby 0-indexed
+s = @mod.samples[cell.sample_number - 1]
+```
+
+## How We Found It
+
+The pattern player was playing sounds that didn't match the expected
+instruments. A kick line was playing a hi-hat, bass lines were playing
+something else. Once we understood the ProTracker convention, the
+off-by-one was obvious.
+
+## Lesson
+
+When parsing a format from the 1980s, always check if indices start
+at 0 or 1. The Amiga demoscene used 1-based indexing for many things
+(samples, patterns), while modern languages use 0-based arrays.
+Document the convention explicitly in your code.

--- a/lib/dr_mod_tracker/sample.rb
+++ b/lib/dr_mod_tracker/sample.rb
@@ -38,9 +38,10 @@ class Sample
 
   # it's an amiga word
   #
+  # Length is stored as words (2 bytes). Multiply by 2 for bytes.
   def set_length
     offset  = offset_for :sample_length
-    @length = decode_amiga_word @mod_data, offset
+    @length = decode_amiga_word(@mod_data, offset) * 2
   end
 
   def set_finetune

--- a/lib/dr_mod_tracker/song.rb
+++ b/lib/dr_mod_tracker/song.rb
@@ -16,10 +16,12 @@ class Song
     set_elements
   end
 
+  # Number of patterns stored in the file.
+  # song_positions contains pattern indices (0-based).
+  # max gives the highest index, +1 for the count.
+  # e.g. patterns 0..17 → max=17 → count=18
   def pattern_count
-    puts "songspositions"
-    puts @song_positions
-    @song_positions.max
+    @song_positions.max + 1
   end
 
   # TODO extract to constant


### PR DESCRIPTION
## Summary
- Fix Amiga word → byte conversion in `set_length` (×2 missing)
- Fix `pattern_count` off-by-one (`max` → `max + 1`)
- Fix ProTracker 1-indexed sample numbers in pattern player
- Filter `sample_number == 0` (no instrument convention)
- Add blog draft posts documenting the bugs

## Root Cause
Two offset bugs combined to corrupt every sample:
1. Sample lengths stored as Amiga words (2 bytes) were read as bytes → half the data
2. Pattern count used max index instead of count → sample data offset 1024 bytes too early

## Result
- Waveforms now show clean, single samples
- Pattern player uses correct instruments
- Sample playback sounds correct

## Test plan
- [x] Visual: waveforms show single clean samples (no more double patterns)
- [x] Audio: samples play at correct pitch
- [x] Pattern player plays correct instruments for each note
- [x] lefthook: rubocop + reek + dr_spec pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)