### PR TITLE
DR 6.x compatibility: explicit requires (#41)

### DIFF
--- a/app/main.rb
+++ b/app/main.rb
@@ -2,6 +2,7 @@ require 'lib/dr_mod_tracker/dr_mod.rb'
 require "app/scenes/concern.rb"
 require "app/scene.rb"
 require "app/scenes/scene_manager.rb"
+require "app/scenes/game.rb"
 require "app/scenes/title.rb"
 require "app/scenes/sample.rb"
 require "app/component/sfx_player/sfx_draw.rb"

--- a/app/scene.rb
+++ b/app/scene.rb
@@ -29,10 +29,5 @@ require "app/component/pattern_player/pattern_side_bar.rb"
 require "app/component/pattern_player/pattern_audio.rb"
 require "app/component/pattern_player.rb"
 
-def load_dep_files path
-  $gtk.list_files(path).each do |file|
-    require File.join(path, file)
-  end
-end
-
-load_dep_files "app/scenes"
+# Scenes are loaded via explicit requires in main.rb.
+# Dynamic loading via $gtk.list_files removed for DR 6.x compatibility.


### PR DESCRIPTION
## Summary
- Remove `load_dep_files` dynamic loading that crashes on DR 6.x
- `$gtk.list_files` returns directories in DR 6.x, causing `concerns.rb does not exist`
- Replace with explicit requires (already used everywhere else)
- Add missing `require "app/scenes/game.rb"`
- Backward compatible with DR 2024 Pro

## Test plan
- [x] DR 6.51 Standard: tracker loads and displays correctly
- [x] DR 2024 Pro: backward compatible, game launches normally
- [x] lefthook: rubocop + reek + dr_spec pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)