### PR TITLE
chore(spec): re-vendorise dr_spec + adopte require_specs + exerce be_a

### DIFF
--- a/app/tests.rb
+++ b/app/tests.rb
@@ -29,9 +29,6 @@ require "lib/dr_mod_tracker/cell.rb"
 require "lib/dr_mod_tracker/pattern.rb"
 
 # --- Specs ---------------------------------------------------------------
-require "spec/cell_spec.rb"
-require "spec/sample_spec.rb"
-require "spec/song_spec.rb"
-require "spec/pattern_spec.rb"
+require_specs
 
 run_specs

--- a/lib/dr_spec/dragon_specs.rb
+++ b/lib/dr_spec/dragon_specs.rb
@@ -1,5 +1,26 @@
 $gtk.log_level = :on
 
+# Charge tous les specs (spec/**/*_spec.rb) recursivement, sur macOS/Linux.
+# OPT-IN : a appeler explicitement. On NE l'appelle pas automatiquement car
+# l'ordre de couverture exige de charger le code applicatif AVANT les specs.
+# Cf. #50, contribution d'iMacTia (porte sur la v2 en helper opt-in).
+#
+# `ls` s'execute dans le cwd du process, alors que `require` est relatif au
+# game dir. On prefixe donc `ls` par le game dir (l'argument passe a
+# dragonruby) pour fonctionner aussi en layout mygame/. Cf. #122.
+def require_specs(current_dir = "spec")
+  game_dir = ($gtk.cli_arguments[:dragonruby] || ".").to_s
+  $gtk.exec("ls #{game_dir}/#{current_dir}").to_s.split("\n").each do |entry|
+    if entry.end_with?("_spec.rb")
+      require "#{current_dir}/#{entry}"
+    elsif !entry.include?(".")
+      require_specs("#{current_dir}/#{entry}")
+    end
+  end
+rescue StandardError
+  puts "require_specs: auto-load indisponible (macOS/Linux uniquement)."
+end
+
 def run_specs(reporter: nil)
   puts "================      running tests ========="
   puts "💨 running tests"

--- a/lib/dr_spec/matchers/type_matchers.rb
+++ b/lib/dr_spec/matchers/type_matchers.rb
@@ -32,3 +32,7 @@ end
 def be_kind_of(expected, fail_with: "")
   BeKindOfMatcher.new(expected, fail_with)
 end
+
+# be_a / be_an : aliases de be_kind_of (cf. #49, contribution d'iMacTia).
+alias be_a be_kind_of
+alias be_an be_kind_of

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -20,6 +20,10 @@ spec "Cell" do
       expect(cell.sample_number).to eq 0
     end
 
+    specify "le numéro d'échantillon est un entier" do
+      expect(cell.sample_number).to be_a(Integer)
+    end
+
     specify "la période est 0" do
       expect(cell.note_period).to eq 0
     end


### PR DESCRIPTION
## Contexte

Propagation de la dernière version de `dr_spec` dans dr_mod, avec exercice réel de deux fonctionnalités (require_specs et be_a) pour écarter tout faux positif.

## Changements

- **Re-vendorisation** de `lib/dr_spec` depuis la source (`projects/dr_spec`). Inclut le fix `cli_arguments[:dragonruby]` dans `require_specs` et les aliases `be_a`/`be_an` de `be_kind_of`.
- **`app/tests.rb`** : les quatre `require "spec/..._spec.rb"` explicites sont remplacés par un unique `require_specs`. L'ordre de couverture est préservé : modules d'E-S/rendu chargés en premier, code applicatif chargé avant `DrSpec::Coverage.start` puis les specs via `require_specs`.
- **`spec/cell_spec.rb`** : ajout d'une assertion `be_a(Integer)` sur `cell.sample_number`.

## require_specs : ADOPTÉ

Garde-fou respecté : après bascule vers `require_specs`, le compte reste à **83 tests verts** (identique à la baseline). `require_specs` charge bien les quatre mêmes specs, sans en ajouter ni en casser.

## Tests avant / après

- Baseline (require explicites) : **83 tests**
- Après `require_specs` seul : **83 tests** (garde-fou OK)
- Après ajout de l'assertion `be_a` : **84 tests** (le +1 est l'assertion volontairement ajoutée)

## be_a exercé

`spec/cell_spec.rb`, contexte « silence » : `expect(cell.sample_number).to be_a(Integer)`.

## Portes

- `bin/dr_spec_quiet` : 84 tests, vert
- `bin/coverage_check` : 94,8 % (seuil 90 %)
- `bin/rubocop_quiet` : 49 fichiers, 0 offense
- hook lefthook (reek + rubocop + dr_spec) : vert au commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)